### PR TITLE
chore: add release-drafter action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,64 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚧 Breaking changes"
+    labels:
+      - "major-bump"
+  - title: "🚀 New Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    labels:
+      - "chore"
+      - "other"
+      - "dependencies"
+  - title: "📝 Documentation"
+    labels:
+      - "documentation"
+version-resolver:
+  major:
+    labels:
+      - "major-bump"
+  minor:
+    labels:
+      - "minor-bump"
+      - "feature"
+  patch:
+    labels:
+      - "patch-bump"
+  default: patch
+exclude-labels:
+  - "skip-changelog"
+autolabeler:
+  - label: "chore"
+    title:
+      - "/chore/i"
+    branch:
+      - '/chore\/.+/'
+      - '/dependabot\/.+/'
+  - label: "fix"
+    title:
+      - "/fix/i"
+    branch:
+      - '/fix\/.+/'
+  - label: "feature"
+    title:
+      - "/feat/i"
+    branch:
+      - '/feature\/.+/'
+      - '/feat\/.+/'
+  - label: "documentation"
+    title:
+      - "/docs/i"
+    branch:
+      - '/docs\/.+/'
+template: |
+  # Changes since $PREVIOUS_TAG
+
+  $CHANGES

--- a/.github/workflows/releasedrafter.yml
+++ b/.github/workflows/releasedrafter.yml
@@ -1,0 +1,17 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## Description
This will draft a release based on changes since the last release.
The changes are based on merged PRs.

## How has this been tested?

Using at work.

## Screenshots (if appropriate):
![bild](https://user-images.githubusercontent.com/1151328/133630261-e76edc38-cc56-4754-b4f9-7673f3ecaf3b.png)

