### PR TITLE
chore: add commitlint and new GitHub action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Build the backend
+name: Sanity checks
 on:
   push:
     branches:
@@ -11,7 +11,7 @@ on:
       - synchronize
 
 jobs:
-  make:
+  checks:
     runs-on: self-hosted # runner label defined in repo settings
     steps:
       - name: Checkout code
@@ -20,5 +20,5 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: "^1.17"
-      - name: Build application
-        run: make build
+      - name: Checks
+        run: make checks

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 build/
+tools/*/*/

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,20 @@ PROJECT_NAME := filmstund
 
 GOFMT_FILES = $(shell go list -f '{{.Dir}}' ./... | grep -v '/pb')
 
-backend:\
+## Default make target
+checks:\
 	lint \
 	fmt  \
 	test \
 	mod-tidy \
 	mod-verify \
+	commitlint \
 	verify-nodiff
-.PHONY: backend
+.PHONY: checks
+
+# Include tooling here
+include tools/commitlint/rules.mk
+# TODO: add graphql linter?
 
 lint:
 	$(info [$@] linting $(PROJECT_NAME)...)

--- a/tools/commitlint/.commitlintrc.js
+++ b/tools/commitlint/.commitlintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+};

--- a/tools/commitlint/package.json
+++ b/tools/commitlint/package.json
@@ -1,0 +1,10 @@
+{
+  "license": "UNLICENSED",
+  "devDependencies": {
+    "@commitlint/cli": "^13.1.0",
+    "@commitlint/config-conventional": "^13.1.0"
+  },
+  "dependencies": {
+    "package.json": "^2.0.1"
+  }
+}

--- a/tools/commitlint/rules.mk
+++ b/tools/commitlint/rules.mk
@@ -1,0 +1,14 @@
+commitlint_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+commitlint_bin := $(commitlint_cwd)/node_modules/.bin/commitlint
+
+$(commitlint_bin): $(commitlint_cwd)/package.json $(commitlint_cwd)/rules.mk
+	$(info [commitlint] downloading...)
+	@cd $(commitlint_cwd) && yarn add --no-lockfile --silent package.json
+	@touch $@
+
+commitlint: $(commitlint_cwd)/.commitlintrc.js $(commitlint_bin)
+	$(info [$@] linting commit messages...)
+	@$(commitlint_bin) \
+		--config $< \
+		--from origin/master
+.PHONY: commitlint


### PR DESCRIPTION
## Description
Now we enforce [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) through a CI job.

Also added is a new action for doing sanity checks. This check has been moved from the backend job to it's own job.

## How has this been tested?

This PR is the test.
