### PR TITLE
fix: proper use of yarn in commitlint target

### DIFF
--- a/tools/commitlint/package.json
+++ b/tools/commitlint/package.json
@@ -3,8 +3,5 @@
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0"
-  },
-  "dependencies": {
-    "package.json": "^2.0.1"
   }
 }

--- a/tools/commitlint/rules.mk
+++ b/tools/commitlint/rules.mk
@@ -3,7 +3,7 @@ commitlint_bin := $(commitlint_cwd)/node_modules/.bin/commitlint
 
 $(commitlint_bin): $(commitlint_cwd)/package.json $(commitlint_cwd)/rules.mk
 	$(info [commitlint] downloading...)
-	@cd $(commitlint_cwd) && yarn add --no-lockfile --silent package.json
+	@yarn install --no-lockfile --silent --cwd $(commitlint_cwd)
 	@touch $@
 
 commitlint: $(commitlint_cwd)/.commitlintrc.js $(commitlint_bin)


### PR DESCRIPTION


## Description

Also removed an old unused dependency that came from the improper use of yarn

## How has this been tested?

Manuallt with `make commitlint`
