### PR TITLE
refactor: change how we download `gofumpt` & `golangci-lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ checks:\
 .PHONY: checks
 
 # Include tooling here
+include tools/golangci-lint/rules.mk
 include tools/gofumpt/rules.mk
 include tools/commitlint/rules.mk
 # TODO: add graphql linter?
 
-lint:
+lint: $(golangci-lint_bin)
 	$(info [$@] linting $(PROJECT_NAME)...)
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	@golangci-lint run --config .golangci.yaml
+	@$< run --config .golangci.yaml
 .PHONY: lint
 
 verify-nodiff:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ checks:\
 .PHONY: checks
 
 # Include tooling here
+include tools/gofumpt/rules.mk
 include tools/commitlint/rules.mk
 # TODO: add graphql linter?
 
@@ -29,10 +30,9 @@ verify-nodiff:
 .PHONY: verify-nodiff
 
 # Format all files
-fmt:
+fmt: $(gofumpt_bin)
 	$(info [$@] formatting all Go files...)
-	@go install mvdan.cc/gofumpt@latest
-	@gofumpt -w $(GOFMT_FILES)
+	@$< -w $(GOFMT_FILES)
 .PHONY: fmt
 
 mod-tidy:

--- a/tools/gofumpt/rules.mk
+++ b/tools/gofumpt/rules.mk
@@ -10,11 +10,11 @@ ifneq ($(system_arch), x86_64)
 $(error unsupported arch: $(uname -m))
 endif
 
-dl_url := https://github.com/mvdan/gofumpt/releases/download/$(gofumpt_ver)/gofumpt_$(gofumpt_ver)_$(system_os)_amd64
+gofumpt_url := https://github.com/mvdan/gofumpt/releases/download/$(gofumpt_ver)/gofumpt_$(gofumpt_ver)_$(system_os)_amd64
 
 $(gofumpt_bin): $(gofumpt_cwd)/rules.mk
 	$(info [gofumpt] downloading $(gofumpt_ver)...)
 	@mkdir -p $(dir $@)
-	@curl --silent --location --show-error $(dl_url) --output "$@"
+	@curl --silent --location --show-error $(gofumpt_url) --output "$@"
 	@chmod +x $@
 	@touch $@

--- a/tools/gofumpt/rules.mk
+++ b/tools/gofumpt/rules.mk
@@ -1,0 +1,20 @@
+#  A stricter gofmt
+gofumpt_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+gofumpt_ver := v0.1.1
+gofumpt_bin := $(gofumpt_cwd)/$(gofumpt_ver)/gofumpt
+
+system_os   := $(shell uname -s)
+system_arch := $(shell uname -m)
+
+ifneq ($(system_arch), x86_64)
+$(error unsupported arch: $(uname -m))
+endif
+
+dl_url := https://github.com/mvdan/gofumpt/releases/download/$(gofumpt_ver)/gofumpt_$(gofumpt_ver)_$(system_os)_amd64
+
+$(gofumpt_bin): $(gofumpt_cwd)/rules.mk
+	$(info [gofumpt] downloading $(gofumpt_ver)...)
+	@mkdir -p $(dir $@)
+	@curl --silent --location --show-error $(dl_url) --output "$@"
+	@chmod +x $@
+	@touch $@

--- a/tools/golangci-lint/rules.mk
+++ b/tools/golangci-lint/rules.mk
@@ -1,0 +1,19 @@
+golangci-lint_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+golangci-lint_ver := 1.42.1
+golangci-lint_bin := $(golangci-lint_cwd)/$(golangci-lint_ver)/golangci-lint
+
+system_os   := $(shell uname -s)
+system_arch := $(shell uname -m)
+
+ifneq ($(system_arch), x86_64)
+$(error unsupported arch: $(uname -m))
+endif
+
+golangci-lint_url := https://github.com/golangci/golangci-lint/releases/download/v$(golangci-lint_ver)/golangci-lint-$(golangci-lint_ver)-$(system_os)-amd64.tar.gz
+
+$(golangci-lint_bin): $(golangci-lint_cwd)/rules.mk
+	$(info [golangci-lint] downloading v$(golangci-lint_ver)...)
+	@mkdir -p $(dir $@)
+	@curl --silent --location --show-error "$(golangci-lint_url)" --output - | tar -xz --directory $(dir $@) --strip-components 1
+	@chmod +x $@
+	@touch $@


### PR DESCRIPTION
## Description

We download binaries directly from GitHub instead of using `go install`. Should be a more portable solution.

## How has this been tested?

Manually with `make`

