### PR TITLE
feat: add a maintenance mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/filmstund/filmstund
 go 1.17
 
 require (
+	github.com/gorilla/mux v1.8.0
 	github.com/sethvargo/go-envconfig v0.3.5
 	go.uber.org/zap v1.19.1
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/internal/fileserver/fileserver.go
+++ b/internal/fileserver/fileserver.go
@@ -7,11 +7,18 @@ import (
 	"os"
 
 	"github.com/filmstund/filmstund/internal/logging"
+	"github.com/filmstund/filmstund/internal/middleware"
+	"github.com/gorilla/mux"
 )
 
 type Config struct {
-	ListenAddr string `env:"LISTEN_ADDR,default=:8080"`
-	ServePath  string `env:"SERVE_PATH,default=./web/build"`
+	ListenAddr  string `env:"LISTEN_ADDR,default=:8080"`
+	ServePath   string `env:"SERVE_PATH,default=./web/build"`
+	Maintenance bool   `env:"MAINTENANCE_MODE, default=false"`
+}
+
+func (c *Config) MaintenanceMode() bool {
+	return c.Maintenance
 }
 
 type Server struct {
@@ -32,9 +39,17 @@ func NewServer(cfg *Config) (*Server, error) {
 	}, nil
 }
 
-func (s *Server) Routes(ctx context.Context) http.Handler {
+func (s *Server) Routes(ctx context.Context) *mux.Router {
 	logger := logging.FromContext(ctx)
 	logger.Debugf("routing / to file://%s", s.cfg.ServePath)
 
-	return http.FileServer(http.Dir(s.cfg.ServePath))
+	r := mux.NewRouter()
+
+	// Middleware
+	r.Use(middleware.ProcessMaintenance(s.cfg))
+
+	// Routing table
+	r.Handle("/", http.FileServer(http.Dir(s.cfg.ServePath)))
+
+	return r
 }

--- a/internal/middleware/maintenance.go
+++ b/internal/middleware/maintenance.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// Maintainable makes sure that a configuration contains the right config item.
+type Maintainable interface {
+	MaintenanceMode() bool
+}
+
+func ProcessMaintenance(maint Maintainable) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if maint.MaintenanceMode() {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				fmt.Fprintf(w, `{"error": "server is down for maintenance mode"}`)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR changes the router to gorilla/mux which allows for more flexibility and middlewares.

When the `MAINTENANCE_MODE=true`, then the server will return `503 Service Unavailable` with an error message.

## How has this been tested?

Manually

