### PR TITLE
refactor(login): separate login into two queries

### DIFF
--- a/configs/database/queries/users.sql
+++ b/configs/database/queries/users.sql
@@ -1,22 +1,21 @@
--- name: NewOrExistingUser :one
-WITH neworexisting AS (
-    INSERT INTO users
-        (subject_id, first_name, last_name, nick, email, avatar)
-        VALUES (@subject, @first_name, @last_name, @nick, @email, @avatar)
-        ON CONFLICT (subject_id) DO
-            UPDATE SET
-                last_login = current_timestamp,
-                last_modified_date = current_timestamp,
-                avatar = @avatar,
-                first_name = @first_name,
-                email = @email
-        RETURNING *
-)
-SELECT *
-FROM neworexisting;
+-- name: CreateUser :one
+INSERT INTO users
+    (subject_id, first_name, last_name, nick, email, avatar)
+VALUES (@subject, @first_name, @last_name, @nick, @email, @avatar)
+ON CONFLICT (subject_id) DO UPDATE SET last_login         = current_timestamp,
+                                       last_modified_date = current_timestamp
+RETURNING *;
 
 -- name: UserExistsBySubject :one
 SELECT exists(SELECT 1 FROM users where subject_id = $1);
+
+-- name: UpdateLoginTimes :one
+UPDATE users
+SET avatar             = @avatar,
+    last_login         = current_timestamp,
+    last_modified_date = current_timestamp
+WHERE subject_id = @subject_id
+returning *;
 
 -- name: UpdateUser :one
 UPDATE users


### PR DESCRIPTION
## Description

Now we don't have to use a "custom" type for the login, but can use the normal user model which allows us to use the regular mapper.

The drawback is that it is two queries, instead of one.

## How has this been tested?

- [ ] Unit tests
- [x] Manually

