### PR TITLE
fix(cors): serve next middleware

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -17,6 +17,6 @@ func Cors(provider site.ConfigProvider) mux.MiddlewareFunc {
 			AllowedHeaders:   []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "Authorization"},
 			AllowCredentials: false,
 		})
-		return http.HandlerFunc(c.HandlerFunc)
+		return c.Handler(next)
 	}
 }


### PR DESCRIPTION
I accidentally forgot to serve the next middleware in the chain making everything börken
