### PR TITLE
feat(login): make state stateless

### DIFF
--- a/internal/auth0/codeflow/flow.go
+++ b/internal/auth0/codeflow/flow.go
@@ -1,13 +1,16 @@
 package codeflow
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/filmstund/filmstund/internal/security"
 	"golang.org/x/oauth2"
 )
 
@@ -17,42 +20,61 @@ var (
 )
 
 type Client struct {
-	audience  string
-	oauthCfg  oauth2.Config
-	verifier  *oidc.IDTokenVerifier
-	pkceCache *stateCache
+	audience string
+	oauthCfg oauth2.Config
+	verifier *oidc.IDTokenVerifier
+	gcm      cipher.AEAD
 }
 
-func NewClient(audience string, oauthCfg oauth2.Config, verifier *oidc.IDTokenVerifier) *Client {
-	return &Client{
-		audience:  audience,
-		oauthCfg:  oauthCfg,
-		verifier:  verifier,
-		pkceCache: newPkceCache(),
+func NewClient(audience string, oauthCfg oauth2.Config, verifier *oidc.IDTokenVerifier) (*Client, error) {
+	// Generate random key - look this up from somewhere if we want to share
+	key := make([]byte, 32) // AES-256
+	_, err := io.ReadFull(rand.Reader, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate encryption key: %w", err)
 	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup GCM cipher: %w", err)
+	}
+
+	return &Client{
+		audience: audience,
+		oauthCfg: oauthCfg,
+		verifier: verifier,
+		gcm:      gcm,
+	}, nil
 }
 
 // generateVerification randomly create the State, Nonce, and CodeVerifier
 // for use in the oauth2 authorization code flow.
-func (c *Client) generateVerification(redirectURL string) (State, Nonce, CodeVerifier) {
-	state := State(security.RandBase64String(43))
-	nonce := Nonce(security.RandBase64String(43))
-	codeVerifier := NewCodeVerifier()
+func (c *Client) generateVerification(redirectURL RedirectURL) (State, Nonce, CodeVerifier) {
+	// TODO: Check max length of URL?
+	var (
+		nonce        = NewNonce(c.gcm.NonceSize())
+		codeVerifier = NewCodeVerifier()
+		state        = NewState(c.gcm, nonce, codeVerifier, redirectURL)
+	)
 
-	c.pkceCache.Add(state, nonce, codeVerifier, redirectURL)
 	return state, nonce, codeVerifier
 }
 
 // AuthCodeURL generates the necessary verification variables and
 // puts them into cache and returns the auth code URL to redirect to.
-func (c *Client) AuthCodeURL(redirectURL string) string {
+func (c *Client) AuthCodeURL(redirectURL RedirectURL) string {
 	state, nonce, codeVerifier := c.generateVerification(redirectURL)
 
 	return c.oauthCfg.AuthCodeURL(
 		state.String(),
 		oidc.Nonce(nonce.String()),
-		oauth2.SetAuthURLParam("audience", c.audience), // not needed if default audience is configured in tenant
-		oauth2.SetAuthURLParam("code_challenge", codeVerifier.CreateChallenge()),
+		oauth2.SetAuthURLParam("audience", c.audience),
+		oauth2.SetAuthURLParam("code_challenge", codeVerifier.Challenge()),
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
 	)
 }
@@ -60,19 +82,22 @@ func (c *Client) AuthCodeURL(redirectURL string) string {
 // validateSate fetch the state from the query and cache and compare
 // that they are equal. If equal, it will return the other verification variables.
 func (c *Client) validateState(r *http.Request) (Verification, error) {
-	stateGiven := State(r.URL.Query().Get("state"))
-	verification, found := c.pkceCache.Get(stateGiven)
-	if !found {
-		return Verification{}, fmt.Errorf("%w: no state in cache", ErrInvalidData)
+	stateGiven, err := StateFromBase64(r.URL.Query().Get("state"))
+	if err != nil {
+		return Verification{}, fmt.Errorf("%w: %v", ErrInvalidData, err)
 	}
 
-	c.pkceCache.Del(stateGiven)
+	verification, err := stateGiven.Open(c.gcm)
+	if err != nil {
+		return Verification{}, fmt.Errorf("%w: %v", ErrInvalidData, err)
+	}
+
 	return verification, nil
 }
 
 // ExchangeCode takes the code and exchanges it for an access token and an ID token.
 // Verifications and sanity checks are done along the way.
-func (c *Client) ExchangeCode(r *http.Request) (*oauth2.Token, *oidc.IDToken, string, error) {
+func (c *Client) ExchangeCode(r *http.Request) (*oauth2.Token, *oidc.IDToken, RedirectURL, error) {
 	verification, err := c.validateState(r)
 	if err != nil {
 		return nil, nil, "", err
@@ -82,7 +107,7 @@ func (c *Client) ExchangeCode(r *http.Request) (*oauth2.Token, *oidc.IDToken, st
 	token, err := c.oauthCfg.Exchange(
 		r.Context(),
 		code,
-		oauth2.SetAuthURLParam("code_verifier", string(verification.codeVerifier)),
+		oauth2.SetAuthURLParam("code_verifier", verification.CodeVerifier.String()),
 	)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("%w: %v", ErrExchangeFailure, err)
@@ -93,11 +118,11 @@ func (c *Client) ExchangeCode(r *http.Request) (*oauth2.Token, *oidc.IDToken, st
 		return nil, nil, "", err
 	}
 
-	if err := validateNonce(verification.nonce, idToken); err != nil {
+	if err := validateNonce(verification.Nonce, idToken); err != nil {
 		return nil, nil, "", err
 	}
 
-	return token, idToken, verification.redirectURL, err
+	return token, idToken, verification.RedirectURL, err
 }
 
 // extractIDToken from the given access token.
@@ -117,7 +142,7 @@ func (c *Client) extractIDToken(token *oauth2.Token, r *http.Request) (*oidc.IDT
 // validateNonce checks that nonce we first generated and stored in cache,
 // is the same one we got from the authorization server.
 func validateNonce(expectedNonce Nonce, idToken *oidc.IDToken) error {
-	cmp := subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(expectedNonce))
+	cmp := subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(expectedNonce.String()))
 	if cmp != 1 {
 		return fmt.Errorf("%w: invalid nonce", ErrInvalidData)
 	}

--- a/internal/auth0/codeflow/flow_test.go
+++ b/internal/auth0/codeflow/flow_test.go
@@ -1,0 +1,29 @@
+package codeflow
+
+import (
+	"bytes"
+	"testing"
+
+	"golang.org/x/oauth2"
+	"gotest.tools/v3/assert"
+)
+
+func TestStateGeneration(t *testing.T) {
+	client, err := NewClient("", oauth2.Config{}, nil)
+	assert.NilError(t, err)
+
+	url := RedirectURL("/showing/b0f2c9fc-05f3-426d-be5d-6d357a657fc1")
+	state, nonce, verifier := client.generateVerification(url)
+
+	actualNonce := state.Nonce(client.gcm)
+	assert.Equal(t, bytes.Compare(nonce, actualNonce), 0)
+
+	verification, err := state.Open(client.gcm)
+	assert.NilError(t, err)
+	assert.Equal(t, bytes.Compare(verifier, verification.CodeVerifier), 0)
+	assert.Equal(t, url, verification.RedirectURL)
+
+	newState, err := StateFromBase64(state.String())
+	assert.NilError(t, err)
+	assert.DeepEqual(t, newState, state)
+}

--- a/internal/auth0/codeflow/state.go
+++ b/internal/auth0/codeflow/state.go
@@ -1,100 +1,100 @@
 package codeflow
 
 import (
+	"crypto/cipher"
 	"crypto/sha256"
 	"encoding/base64"
-	"sync"
-	"time"
+	"fmt"
 
 	"github.com/filmstund/filmstund/internal/security"
 )
 
+const codeVerifierSize = 96 // in bytes (should equal between 43 and 128 chars when base64 encoded, RFC 7636)
+
 type (
-	stateCache struct {
-		cache map[State]Verification // TODO: switch to gocache?
-		mu    sync.RWMutex
-	}
+	State        []byte
+	CodeVerifier []byte
+	Nonce        []byte
+	RedirectURL  string
 
 	Verification struct {
-		nonce        Nonce
-		codeVerifier CodeVerifier
-		redirectURL  string // optional URL that we should redirect to upon successful login
-		expiresAt    time.Time
+		Nonce        Nonce
+		RedirectURL  RedirectURL
+		CodeVerifier CodeVerifier
 	}
-
-	State        string
-	CodeVerifier string
-	Nonce        string
 )
 
-// newPkceCache creates a new cache instance.
-func newPkceCache() *stateCache {
-	return &stateCache{
-		cache: map[State]Verification{},
-		mu:    sync.RWMutex{},
-	}
-}
-
-// Get the all verification variables for the state.
-func (p *stateCache) Get(state State) (Verification, bool) {
-	p.invalidateOldEntries()
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	verification, itemFound := p.cache[state]
-	return verification, itemFound
-}
-
-// Add code verifier for the given state.
-func (p *stateCache) Add(state State, nonce Nonce, codeVerifier CodeVerifier, redirectURL string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.cache[state] = Verification{
-		nonce:        nonce,
-		codeVerifier: codeVerifier,
-		redirectURL:  redirectURL,
-		expiresAt:    time.Now().Add(10 * time.Minute),
-	}
-}
-
-// Del removes the code verifier for the given state.
-func (p *stateCache) Del(state State) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	delete(p.cache, state)
-}
-
-// invalidate old entries in the cache.
-func (p *stateCache) invalidateOldEntries() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	now := time.Now()
-	for state, pkce := range p.cache {
-		if pkce.expiresAt.Before(now) {
-			delete(p.cache, state)
-		}
-	}
-}
-
-// NewCodeVerifier creates a new random 128 char code verifier.
 func NewCodeVerifier() CodeVerifier {
-	return CodeVerifier(security.RandBase64String(96))
+	return security.RandBytes(codeVerifierSize)
 }
 
-// CreateChallenge creates a challenge from this code verifier.
-func (cv *CodeVerifier) CreateChallenge() string {
-	sum := sha256.Sum256([]byte(*cv))
+// Challenge creates a challenge from this code verifier.
+func (cv *CodeVerifier) Challenge() string {
+	sum := sha256.Sum256([]byte(cv.String()))
 	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-func (s State) String() string {
-	return string(s)
-}
-
+// String returns the code verifier as base64 encoded string.
 func (cv CodeVerifier) String() string {
-	return string(cv)
+	return base64.RawURLEncoding.EncodeToString(cv)
 }
 
+// NewState constructs an encrypted state based on the given parameters.
+func NewState(gcm cipher.AEAD, nonce Nonce, codeVerifier CodeVerifier, redirectURL RedirectURL) State {
+	plaintext := make([]byte, len(codeVerifier)+len(redirectURL)) // nonce will be added before ciphertext
+	copy(plaintext[:len(codeVerifier)], codeVerifier)
+	copy(plaintext[len(codeVerifier):], redirectURL)
+
+	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
+	state := make([]byte, len(nonce)+len(ciphertext))
+	copy(state, nonce)
+	copy(state[len(nonce):], ciphertext)
+	return state
+}
+
+func StateFromBase64(s string) (State, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}
+
+// String returns the state as a base64 encoded string.
+func (s State) String() string {
+	return base64.RawURLEncoding.EncodeToString(s)
+}
+
+// Nonce extracts the nonce from the state.
+// Basically returns a slice of the first 12 bytes.
+func (s State) Nonce(gcm cipher.AEAD) []byte {
+	return s[:gcm.NonceSize()]
+}
+
+// Open decrypts the state and returns the contents in cleartext.
+func (s State) Open(gcm cipher.AEAD) (Verification, error) {
+	nonce := s.Nonce(gcm)
+	ciphertext := s[gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return Verification{}, fmt.Errorf("failed to decrypt state: %w", err)
+	}
+
+	// Code verifier goes first and the rest is the URL
+	var (
+		codeVer     = CodeVerifier(plaintext[:codeVerifierSize])
+		redirectURL = RedirectURL(plaintext[codeVerifierSize:])
+	)
+
+	return Verification{
+		Nonce:        nonce,
+		RedirectURL:  redirectURL,
+		CodeVerifier: codeVer,
+	}, nil
+}
+
+// NewNonce generates a new random nonce with the given size.
+func NewNonce(size int) Nonce {
+	return security.RandBytes(size)
+}
+
+// String returns the nonce as a base64 encoded string.
 func (n Nonce) String() string {
-	return string(n)
+	return base64.RawURLEncoding.EncodeToString(n)
 }

--- a/internal/security/utils.go
+++ b/internal/security/utils.go
@@ -16,11 +16,16 @@ func RandBase64String(sizeInBytes int) string {
 		sizeInBytes = 96
 	}
 
-	buf := make([]byte, sizeInBytes)
+	buf := RandBytes(sizeInBytes)
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+func RandBytes(size int) []byte {
+	buf := make([]byte, size)
 	_, err := io.ReadFull(rand.Reader, buf)
 	if err != nil {
 		panic(fmt.Errorf("failed to generate random bytes: %w", err))
 	}
 
-	return base64.RawURLEncoding.EncodeToString(buf)
+	return buf
 }


### PR DESCRIPTION
Instead of generating the state and caching the verification variables
using said state in-memory, we encrypt it using AES-GCM and send it to
the authorization server.

This works since the state is passed back to us during the code
exchange. We can also reuse the nonce for encryption and CSRF protection
since the nonce is used to decrypt the state. If it were somehow
tampered with, we wouldn't be able to decrypt and verify the state.

This solves a denial-of-service attack where an attacker could spam
login requests without ever following the redirect URL thus exhausting
all available memory.

## How has this been tested?

- [x] Unit tests
- [x] Manually
