### PR TITLE
refactor(logging): use `logr` instead of `zap`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/filmstund/filmstund
 go 1.17
 
 require (
-	edholm.dev/go-logging v0.0.0
+	edholm.dev/go-logging v1.0.0
 	github.com/99designs/gqlgen v0.14.0
 	github.com/MicahParks/keyfunc v0.9.0
 	github.com/allegro/bigcache/v3 v3.0.1
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/eko/gocache/v2 v2.1.0
+	github.com/go-logr/logr v1.2.0
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/uuid v1.3.0
@@ -19,7 +20,6 @@ require (
 	github.com/sethvargo/go-envconfig v0.3.5
 	github.com/spf13/pflag v1.0.5
 	github.com/vektah/gqlparser/v2 v2.2.0
-	go.uber.org/zap v1.19.1
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	gotest.tools/v3 v3.0.3
 )
@@ -33,6 +33,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-redis/redis/v8 v8.9.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
@@ -66,6 +67,7 @@ require (
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
+	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20211013171255-e13a2654a71e // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-edholm.dev/go-logging v0.0.0 h1:4BGFczQhNoPsrfTV5iY+zhDctsDtL9MPXve5djZGDi4=
-edholm.dev/go-logging v0.0.0/go.mod h1:KhdTkWtmdWxL37lQ5/FYc4NcM5xwoK35nZfulnmdFdg=
+edholm.dev/go-logging v1.0.0 h1:3muDT1giZBt42B0PVGLdTZVd1Lml4WMGFhmgxuKMFEU=
+edholm.dev/go-logging v1.0.0/go.mod h1:pfLIXaPBZ2rPPo/Fx8UPmyyAPAxPltKrf16en82eP/s=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 github.com/99designs/gqlgen v0.14.0 h1:Wg8aNYQUjMR/4v+W3xD+7SizOy6lSvVeQ06AobNQAXI=
 github.com/99designs/gqlgen v0.14.0/go.mod h1:S7z4boV+Nx4VvzMUpVrY/YuHjFX4n7rDyuTqvAkuoRE=
@@ -443,6 +443,10 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
+github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -1188,6 +1192,7 @@ go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723 h1:sHOAIxRGBp443oHZIPB+HsUGaksVCXVQENPxwTfQdH4=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -1200,6 +1205,7 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.19.1 h1:ue41HOKd1vGURxrmeKIgELGb3jPW9DMUDGtsinblHwI=
 go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1530,6 +1536,7 @@ golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/auth0/config.go
+++ b/internal/auth0/config.go
@@ -64,7 +64,7 @@ func fetchJwksUntilFound(ctx context.Context, jwksURL string) *keyfunc.JWKs {
 	refreshInterval := 48 * time.Hour
 	refreshRateLimit := 7 * time.Minute
 	errorHandler := func(err error) {
-		logger.Warnw("failed to refresh JWKS", "err", err, "url", jwksURL)
+		logger.Info("failed to refresh JWKS", "err", err, "url", jwksURL)
 	}
 
 	attempt := 0
@@ -73,7 +73,7 @@ func fetchJwksUntilFound(ctx context.Context, jwksURL string) *keyfunc.JWKs {
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Debugf("context cancelled, bailing out without JWKS...")
+			logger.V(1).Info("context cancelled, bailing out without JWKS...")
 			return nil
 		case <-ticker.C:
 			jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{
@@ -86,11 +86,11 @@ func fetchJwksUntilFound(ctx context.Context, jwksURL string) *keyfunc.JWKs {
 			if err != nil {
 				attempt++
 				ticker.Reset(exponentialBackoff(attempt))
-				logger.Infow("failed to download JWKS", "url", jwksURL, "err", err, "attempt", attempt)
+				logger.Info("failed to download JWKS", "url", jwksURL, "err", err, "attempt", attempt)
 				continue
 			}
 
-			logger.Debugw("downloaded JWKs", "attempt", attempt, "url", jwksURL)
+			logger.V(1).Info("downloaded JWKs", "attempt", attempt, "url", jwksURL)
 			return jwks
 		}
 	}

--- a/internal/auth0/handlers.go
+++ b/internal/auth0/handlers.go
@@ -87,13 +87,13 @@ func (s *Handler) LoginCallbackHandler() http.Handler {
 		accessToken, idToken, redirectURL, err := s.codeFlowClient.ExchangeCode(r)
 		if err != nil {
 			httputils.BadRequest(w, r, "invalid data")
-			logger.Warnw("code exchange failed", "err", err)
+			logger.Info("code exchange failed", "err", err)
 			return
 		}
 
 		if err := s.startNewSession(w, r, accessToken, idToken); err != nil {
 			httputils.InternalServerError(w, r)
-			logger.Warnw("failed to start new session", "err", err)
+			logger.Info("failed to start new session", "err", err)
 			return
 		}
 		if redirectURL != "" && strings.HasPrefix(string(redirectURL), "/") {
@@ -159,13 +159,13 @@ func (s *Handler) LogoutHandler() http.Handler {
 		logoutURL, err := s.logoutURL()
 		if err != nil {
 			httputils.InternalServerError(w, r)
-			logger.Warnw("failed to create logout URL", "err", err)
+			logger.Info("failed to create logout URL", "err", err)
 			return
 		}
 
 		if err = s.sessionStorage.Invalidate(r.Context(), w, r); err != nil {
 			httputils.InternalServerError(w, r)
-			logger.Warnw("failed to invalidate session", "err", err)
+			logger.Info("failed to invalidate session", "err", err)
 		}
 		http.Redirect(w, r, logoutURL, http.StatusFound)
 	})

--- a/internal/cinema/cinemaserver.go
+++ b/internal/cinema/cinemaserver.go
@@ -46,7 +46,6 @@ func NewServer(ctx context.Context, cfg *Config, env *serverenv.ServerEnv) (*Ser
 
 func (s *Server) Routes(ctx context.Context) *mux.Router {
 	logger := logging.FromContext(ctx)
-	logger.Debugf("routing / to file://%s", s.cfg.ServePath)
 
 	notAuthed := mux.NewRouter()
 

--- a/internal/database/connections.go
+++ b/internal/database/connections.go
@@ -50,6 +50,6 @@ func (db *DB) Queries(ctx context.Context) (q *sqlc.Queries, cleanup func(), err
 func noop() {}
 
 func (db *DB) Close(ctx context.Context) {
-	logging.FromContext(ctx).Infof("closing database connection pool...")
+	logging.FromContext(ctx).Info("closing database connection pool...")
 	db.Pool.Close()
 }

--- a/internal/graph/commandments.resolvers.go
+++ b/internal/graph/commandments.resolvers.go
@@ -23,7 +23,7 @@ func (r *queryResolver) AllCommandments(ctx context.Context) ([]*model.Commandme
 
 	all, err := q.ListCommandments(ctx)
 	if err != nil {
-		logger.Warnw("AllCommandments failed", "err", err)
+		logger.Info("AllCommandments failed", "err", err)
 		return nil, fmt.Errorf("failed to list all commandments: %w", err)
 	}
 
@@ -48,7 +48,7 @@ func (r *queryResolver) RandomCommandment(ctx context.Context) (*model.Commandme
 
 	rnd, err := q.RandomCommandment(ctx)
 	if err != nil {
-		logger.Warnw("RandomCommandment failed", "err", err)
+		logger.Info("RandomCommandment failed", "err", err)
 		return nil, fmt.Errorf("RandomCommandment query failed: %w", err)
 	}
 

--- a/internal/graph/users.resolvers.go
+++ b/internal/graph/users.resolvers.go
@@ -26,7 +26,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, newInfo model.UserDet
 
 	user, err := q.UpdateUser(ctx, mappers.ToUpdateUserParams(newInfo, princ.Subject))
 	if err != nil {
-		logger.Infow("failed to update user", "sub", princ.Subject, "err", err)
+		logger.Info("failed to update user", "sub", princ.Subject, "err", err)
 		return nil, fmt.Errorf("failed to update user")
 	}
 	return mappers.ToGraphUser(user, r.siteCfg), nil
@@ -44,7 +44,7 @@ func (r *mutationResolver) InvalidateCalendarFeed(ctx context.Context) (*model.U
 
 	user, err := q.RandomizeCalendarFeed(ctx, princ.Subject.String())
 	if err != nil {
-		logger.Infow("failed to invalidate calendar feed", "sub", princ.Subject, "err", err)
+		logger.Info("failed to invalidate calendar feed", "sub", princ.Subject, "err", err)
 		return nil, fmt.Errorf("failed to invalidate calendar feed")
 	}
 	return mappers.ToGraphUser(user, r.siteCfg), nil
@@ -62,7 +62,7 @@ func (r *mutationResolver) DisableCalendarFeed(ctx context.Context) (*model.User
 
 	user, err := q.DisableCalendarFeed(ctx, princ.Subject.String())
 	if err != nil {
-		logger.Infow("failed to disable calendar feed", "sub", princ.Subject, "err", err)
+		logger.Info("failed to disable calendar feed", "sub", princ.Subject, "err", err)
 		return nil, fmt.Errorf("failed to disable calendar feed")
 	}
 	return mappers.ToGraphUser(user, r.siteCfg), nil
@@ -82,14 +82,14 @@ func (r *queryResolver) CurrentUser(ctx context.Context) (*model.User, error) {
 
 	queries, cleanup, err := r.db.Queries(ctx)
 	if err != nil {
-		logger.Infow("failed to connect to database", "err", err)
+		logger.Info("failed to connect to database", "err", err)
 		return nil, fmt.Errorf("failed to connect to database")
 	}
 	defer cleanup()
 
 	user, err := queries.GetUser(ctx, princ.ID)
 	if err != nil {
-		logger.Infow("failed to get user", "id", princ.ID, "err", err)
+		logger.Info("failed to get user", "id", princ.ID, "err", err)
 		return nil, fmt.Errorf("failed to get user")
 	}
 

--- a/internal/httputils/httputils.go
+++ b/internal/httputils/httputils.go
@@ -103,12 +103,12 @@ func sendError(w http.ResponseWriter, r *http.Request, status int, response Erro
 
 	bytes, err := json.Marshal(response)
 	if err != nil {
-		logger.Warnw("failed to unmarshal error response", "err", err)
+		logger.Info("failed to unmarshal error response", "err", err)
 		return
 	}
 
 	if _, err = w.Write(bytes); err != nil {
-		logger.Warnw("failed to write error response", "err", err)
+		logger.Info("failed to write error response", "err", err)
 		return
 	}
 }

--- a/internal/middleware/authorization.go
+++ b/internal/middleware/authorization.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -9,14 +10,14 @@ import (
 	"github.com/filmstund/filmstund/internal/auth0"
 	"github.com/filmstund/filmstund/internal/auth0/principal"
 	"github.com/filmstund/filmstund/internal/httputils"
+	"github.com/go-logr/logr"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
 )
 
 type jwtVerifier struct {
 	cfg    *auth0.Config
-	logger *zap.SugaredLogger
+	logger logr.Logger
 }
 
 // ApplyAuthorization validates the JWT token in the "Authorization" header.
@@ -28,8 +29,7 @@ func ApplyAuthorization(cfg *auth0.Config) mux.MiddlewareFunc {
 			verifier := jwtVerifier{
 				cfg: cfg,
 				logger: logging.FromContext(r.Context()).
-					With("url", r.URL.String()).
-					With("from", r.RemoteAddr),
+					WithValues("url", r.URL.String(), "from", r.RemoteAddr),
 			}
 
 			token, err := verifier.doAuthorization(r)
@@ -57,7 +57,7 @@ func ApplyAuthorization(cfg *auth0.Config) mux.MiddlewareFunc {
 func (v *jwtVerifier) doAuthorization(r *http.Request) (*jwt.Token, error) {
 	rawToken, exists := httputils.ExtractTokenFromHeader(r)
 	if !exists {
-		v.logger.Debugf("[token] missing authorization header")
+		v.logger.V(1).Info("[token] missing authorization header")
 		return nil, httputils.ErrUnauthorized
 	}
 
@@ -67,37 +67,37 @@ func (v *jwtVerifier) doAuthorization(r *http.Request) (*jwt.Token, error) {
 	// Parse and validate the token
 	token, err := jwt.ParseWithClaims(rawToken, &auth0.Claims{}, jwks.Keyfunc)
 	if err != nil {
-		v.logger.Debugw("[token] invalid token", "err", err)
+		v.logger.V(1).Info("[token] invalid token", "err", err)
 		return nil, httputils.ErrUnauthorized
 	}
 
 	// Verify token is signed with expected algorithm
 	// https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
 	if token.Header["alg"] != v.cfg.Algorithm {
-		v.logger.Debugw("[token] signed with wrong alg", "alg", token.Header["alg"])
+		v.logger.V(1).Info("[token] signed with wrong alg", "alg", token.Header["alg"])
 		return nil, httputils.ErrUnauthorized
 	}
 
 	// Verify token has the expected issuer, audience, expires at claims
 	claims, castOK := token.Claims.(*auth0.Claims)
 	if !castOK {
-		v.logger.Errorf("failed to cast claims, got type %T", token.Claims)
+		v.logger.Info("failed to cast claims", "type", fmt.Sprintf("%T", token.Claims))
 		return nil, httputils.ErrInternal
 	}
 
 	if !claims.VerifyAudience(v.cfg.Audience, true) {
-		v.logger.Debugw("[token] couldn't verify audience", "audience", claims.Audience, "expected", v.cfg.Audience)
+		v.logger.V(1).Info("[token] couldn't verify audience", "audience", claims.Audience, "expected", v.cfg.Audience)
 		return nil, httputils.ErrUnauthorized
 	}
 
 	if !claims.VerifyIssuer(v.cfg.Issuer) {
-		v.logger.Debugw("[token] couldn't verify issuer", "issuer", claims.Issuer, "expected", v.cfg.Issuer)
+		v.logger.V(1).Info("[token] couldn't verify issuer", "issuer", claims.Issuer, "expected", v.cfg.Issuer)
 		return nil, httputils.ErrUnauthorized
 	}
 
 	// verify that this claim actually exists TODO: use timefunc instead of time.Now()
 	if !claims.VerifyExpiresAt(time.Now(), true) {
-		v.logger.Debugw("[token] token has expired or doesn't have expire at claim", "expiresAt", claims.ExpiresAt)
+		v.logger.V(1).Info("[token] token has expired or doesn't have expire at claim", "expiresAt", claims.ExpiresAt)
 		return nil, httputils.ErrUnauthorized
 	}
 
@@ -109,7 +109,7 @@ func (v *jwtVerifier) doAuthorization(r *http.Request) (*jwt.Token, error) {
 // you will have valid principal that is put into the cache, else an error.
 func (v *jwtVerifier) extractPrincipal(token *jwt.Token) (*principal.Principal, error) {
 	if token == nil || !token.Valid {
-		v.logger.Errorf("no/invalid token supplied. Missing authorization?")
+		v.logger.Info("no/invalid token supplied. Missing authorization?")
 		return nil, httputils.ErrInternal
 	}
 

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 
 	"edholm.dev/go-logging"
+	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
-	"go.uber.org/zap"
 )
 
-func AttachAppLogger(logger *zap.SugaredLogger) mux.MiddlewareFunc {
+func AttachAppLogger(logger logr.Logger) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"edholm.dev/go-logging"
-	"go.uber.org/zap"
+	"github.com/go-logr/logr"
 	"gotest.tools/v3/assert"
 )
 
@@ -14,7 +14,7 @@ func TestAttachAppLogger(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name   string
-		logger *zap.SugaredLogger
+		logger logr.Logger
 	}{
 		{
 			name:   "Default logger",
@@ -22,7 +22,7 @@ func TestAttachAppLogger(t *testing.T) {
 		},
 		{
 			name:   "Custom logger",
-			logger: zap.NewExample().Sugar(),
+			logger: logr.Discard(),
 		},
 	}
 	for _, tt := range tests {
@@ -36,7 +36,7 @@ func TestAttachAppLogger(t *testing.T) {
 			w := httptest.NewRecorder()
 			r := http.Request{}
 
-			var actualLogger *zap.SugaredLogger
+			var actualLogger logr.Logger
 			handlerFunc(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 				actualLogger = logging.FromContext(request.Context())
 				w.WriteHeader(http.StatusOK)

--- a/internal/middleware/recover.go
+++ b/internal/middleware/recover.go
@@ -17,7 +17,7 @@ func RecoverPanic() mux.MiddlewareFunc {
 			defer func() {
 				rec := recover()
 				if rec != nil {
-					logger.Errorw("panic occurred", "url", r.RequestURI, "panic", rec)
+					logger.Info("panic occurred", "url", r.RequestURI, "panic", rec)
 					// TODO: replace with something more convenient
 					http.Error(w, `{"error": "an unexpected error occurred"}`, http.StatusInternalServerError)
 				}

--- a/internal/middleware/session.go
+++ b/internal/middleware/session.go
@@ -14,12 +14,11 @@ func AuthorizeSession(sessionStorage *session.Storage) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := logging.FromContext(r.Context()).
-				With("url", r.URL.String()).
-				With("from", r.RemoteAddr)
+				WithValues("url", r.URL.String(), "from", r.RemoteAddr)
 
 			prin, err := sessionStorage.Lookup(r.Context(), r)
 			if err != nil {
-				logger.Debugw("failed to validate session", "err", err)
+				logger.V(1).Info("failed to validate session", "err", err)
 				httputils.Unauthorized(w, r)
 				return
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,20 +42,20 @@ func (s *Server) ServeHTTP(ctx context.Context, srv *http.Server) error {
 	go func() {
 		<-ctx.Done()
 
-		logger.Debugf("http.Server: context closed")
+		logger.V(2).Info("http.Server: context closed")
 		timeCtx, cancelFunc := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancelFunc()
 
-		logger.Debugf("http.Server: shutting down")
+		logger.V(1).Info("http.Server: shutting down")
 		errCh <- srv.Shutdown(timeCtx)
 	}()
 
-	logger.Infof("listening for HTTP on %s", s.Addr())
+	logger.Info("listening for HTTP", "addr", s.Addr())
 	if err := srv.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("failed to serve HTTP: %w", err)
 	}
 
-	logger.Debugf("stopped listening for HTTP")
+	logger.V(1).Info("stopped listening for HTTP")
 	select {
 	case err := <-errCh:
 		return fmt.Errorf("failed to shutdown server: %w", err)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -27,7 +27,7 @@ func Setup(ctx context.Context, cfg interface{}) (*serverenv.ServerEnv, error) {
 	if err := envconfig.Process(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("failed to process config: %w", err)
 	}
-	logger.Debugw("using config", "config", cfg)
+	logger.V(1).Info("using config", "config", cfg)
 
 	options := make([]serverenv.Option, 0, 3)
 


### PR DESCRIPTION
Changes to discrete levels to a verbosity level instead where higher
numbers are more verbose. 0 == info, 1 == debug, 2 == trace, etc


## How has this been tested?

- [x] Unit tests
- [x] Manually
