### PR TITLE
fix: add import interop workaround for react-day-picker

### DIFF
--- a/web/src/use-cases/common/ui/date-picker/DatePickerInput.tsx
+++ b/web/src/use-cases/common/ui/date-picker/DatePickerInput.tsx
@@ -1,10 +1,18 @@
 import React from "react";
 
 import { LocaleUtils } from "react-day-picker";
-import DayPickerInput from "react-day-picker/DayPickerInput";
+import DayPickerInputNS from "react-day-picker/DayPickerInput";
 import "./date-picker.css";
 import { formatYMD } from "../../../../lib/dateTools";
 import { DayPickerInputProps } from "react-day-picker/types/Props";
+
+// Vite & rollup has an issue with cjs default export
+// https://github.com/vitejs/vite/issues/2139#issuecomment-854960323
+function interopDefault<T>(value: T): T {
+  return (value as any).default;
+}
+
+const DayPickerInput = interopDefault(DayPickerInputNS);
 
 const localeUtils = {
   ...LocaleUtils,

--- a/web/src/use-cases/user/EditableForetagsbiljettList.tsx
+++ b/web/src/use-cases/user/EditableForetagsbiljettList.tsx
@@ -42,7 +42,7 @@ export interface ForetagsbiljettInputDraft {
   expires: Temporal.PlainDate;
 }
 
-const EditableForetagsbiljettList: React.FC = () => {
+export const EditableForetagsbiljettList: React.FC = () => {
   const [tickets, setTickets] = useState<ForetagsbiljettInputDraft[]>([]);
   const [, saveForetagsBiljetter] = useAddGiftCertificatesMutation();
 
@@ -120,5 +120,3 @@ const EditableForetagsbiljettList: React.FC = () => {
     </>
   );
 };
-
-export default EditableForetagsbiljettList;

--- a/web/src/use-cases/user/ForetagsbiljettList.tsx
+++ b/web/src/use-cases/user/ForetagsbiljettList.tsx
@@ -22,13 +22,6 @@ export const ForetagsbiljettList: React.FC<Props> = ({ foretagsbiljetter }) => {
   const handleDeleteForetagsBiljett = useCallback(
     ({ status, number, expireTime }: GiftCertificateFragment) => {
       switch (status) {
-        case GiftCertificate_Status.Available:
-          if (window.confirm("Är du säker på att du vill ta bort biljetten?")) {
-            deleteGiftCertificate({
-              ticket: { number, expireTime },
-            });
-          }
-          break;
         case GiftCertificate_Status.Pending:
           window.alert(
             "Biljetten används på en visning som ej har bokats ännu"
@@ -40,8 +33,13 @@ export const ForetagsbiljettList: React.FC<Props> = ({ foretagsbiljetter }) => {
             ticket: { number, expireTime },
           });
           break;
+        case GiftCertificate_Status.Available:
         default:
-          throw new Error(`Invalid status ${status}`);
+          if (window.confirm("Är du säker på att du vill ta bort biljetten?")) {
+            deleteGiftCertificate({
+              ticket: { number, expireTime },
+            });
+          }
       }
     },
     [deleteGiftCertificate]

--- a/web/src/use-cases/user/ForetagsbiljettList.tsx
+++ b/web/src/use-cases/user/ForetagsbiljettList.tsx
@@ -7,7 +7,7 @@ import {
   useDeleteGiftCertificateMutation,
   UserProfileQuery,
 } from "../../__generated__/types";
-import EditableForetagsbiljettList from "./EditableForetagsbiljettList";
+import { EditableForetagsbiljettList } from "./EditableForetagsbiljettList";
 
 import { Foretagsbiljett } from "./Foretagsbiljett";
 import { InputSpinner } from "../single-showing/InputSpinner";


### PR DESCRIPTION
- fix: add import interop workaround for react-day-picker
- fix: do not crash on unknown ticket status


## How has this been tested?

- [ ] Unit tests
- [x] Manually

## Screenshots
