### PR TITLE
chore: disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: chore
-      include: scope
+#  - package-ecosystem: "gomod"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#    commit-message:
+#      prefix: chore
+#      include: scope
 
-  - package-ecosystem: "npm"
-    directory: "/web"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: chore
-      include: scope
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch" ]
+#  - package-ecosystem: "npm"
+#    directory: "/web"
+#    schedule:
+#      interval: "weekly"
+#    commit-message:
+#      prefix: chore
+#      include: scope
+#    ignore:
+#      - dependency-name: "*"
+#        update-types: [ "version-update:semver-patch" ]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Repo isn't receiving active development right now so we'll pause it for now.
